### PR TITLE
Trace Network Hops(IPv4)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module simpleroute
+
+go 1.17
+
+require golang.org/x/net v0.0.0-20220403103023-749bd193bc2b
+
+require golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+golang.org/x/net v0.0.0-20220403103023-749bd193bc2b h1:vI32FkLJNAWtGD4BwkThwEy6XS7ZLLMHkSkYfF8M0W0=
+golang.org/x/net v0.0.0-20220403103023-749bd193bc2b/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/simpleroute.go
+++ b/simpleroute.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Arg Err")
+		os.Exit(1)
+	}
+	s_addr := os.Args[1]
+	fmt.Printf("s_addr %s\n",s_addr)
+}

--- a/simpleroute.go
+++ b/simpleroute.go
@@ -2,14 +2,101 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"net"
 	"os"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"golang.org/x/net/ipv4"
 )
+
+func sliceAtob(strings []string) ([]byte, error) {
+	bytes := make([]byte, 0, len(strings))
+
+	for _, str := range strings {
+		i, err := strconv.Atoi(str)
+		if err != nil {
+			return bytes, err
+		}
+		bytes = append(bytes, byte(i))
+	}
+
+	return bytes, nil
+}
+
+func calc_checksum(b []byte) uint16 {
+	var sum uint32
+	for i := 0; i < len(b); i += 2 {
+		sum += uint32(b[i]) | (uint32(b[i+1]) << 8)
+	}
+	sum = (sum >> 16) + (sum & 0xffff)
+	sum = (sum >> 16) + (sum & 0xffff)
+	return uint16(^sum)
+}
+
+func make_packet(dst []byte) ([]byte, error) {
+	v4header := ipv4.Header{
+		Version:  4,
+		Len:      20,
+		TotalLen: 30,
+		TTL:      4,
+		Protocol: 1, //ICMP
+		Dst:      net.IPv4(dst[0], dst[1], dst[2], dst[3]),
+	}
+
+	icmp := []byte{
+		8,    //Type ICMP echo message
+		0,    //Code
+		0,    //Checksum
+		0,    //Checksum
+		0,    //Identifier
+		0,    //Identifier
+		0,    //Sequence Number
+		0,    //Sequence Number
+		0xc0, //Data
+		0xDE, //Data
+	}
+	checksum := calc_checksum(icmp)
+	icmp[2] = byte(checksum)
+	icmp[3] = byte(checksum >> 8)
+
+	ippacket, err := v4header.Marshal()
+	if err != nil {
+		return ippacket, err
+	}
+	return append(ippacket, icmp...), nil
+}
 
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Println("Arg Err")
 		os.Exit(1)
 	}
-	s_addr := os.Args[1]
-	fmt.Printf("s_addr %s\n",s_addr)
+
+	s_addr, err := sliceAtob(strings.Split(os.Args[1], "."))
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("s_addr %d\n", s_addr)
+
+	sfd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_RAW, syscall.IPPROTO_RAW)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	sock_addr := syscall.SockaddrInet4{
+		Port: 0,
+		Addr: [4]byte{s_addr[0], s_addr[1], s_addr[2], s_addr[3]},
+	}
+	packet, err := make_packet(s_addr)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = syscall.Sendto(sfd, packet, 0, &sock_addr)
+	if err != nil {
+		log.Fatal(err)
+	}
 }


### PR DESCRIPTION
# Abstract
This feature can output network hops for specified IPv4 addresses.
It sends an ICMP echo packet that TTL incremented.
if routers on the destination are received packets that TTL was zero, it replies ICMP TTL Exceeded packet.
Therefore, it can obtain router addresses by  IPv4 source address of ICMP TTL Exceeded packet.

# example
As below, we can obtain its information by executing commands.
```
sudo simpleroute xxx.xxx.xxx.xxx
```